### PR TITLE
[FIX]: License validation

### DIFF
--- a/app/Commands/Exceptions/LicenseNotFound.php
+++ b/app/Commands/Exceptions/LicenseNotFound.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Commands\Exceptions;
+
+class LicenseNotFound extends \Exception
+{
+    public function __construct(string $license)
+    {
+        parent::__construct("The license '{$license}' is not valid.");
+    }
+}

--- a/app/Commands/PackageInitCommand.php
+++ b/app/Commands/PackageInitCommand.php
@@ -185,7 +185,13 @@ class PackageInitCommand extends Command implements PromptsForMissingInput
 
     protected function getLicense(): string
     {
-        return $this->option('license') ?? 'MIT';
+        $license = $this->option('license') ?? 'MIT';
+
+        if (! \App\Facades\Composer::validateLicense($license)) {
+            throw new Exceptions\LicenseNotFound($license);
+        }
+
+        return $license;
     }
 
     protected function getNamespace(): string

--- a/app/Composer.php
+++ b/app/Composer.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Facades\Process;
 
 class Composer
 {
+    use Traits\WithLicense;
+
     public function install(): void
     {
         $this->runProcess('install');

--- a/app/Facades/Composer.php
+++ b/app/Facades/Composer.php
@@ -6,6 +6,25 @@ namespace App\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
+
+/**
+ * Facade for Composer operations that includes license validation functionality.
+ *
+ * This facade provides a simple interface for running Composer commands and handling
+ * license validations through the associated trait.
+ *
+ * @method static void install() Installs the project dependencies using Composer.
+ * @method static void require(string $package, bool $dev = false) Adds a package dependency with an option for development.
+ * @method static void remove(string $package, bool $dev = false) Removes a package dependency with an option for development.
+ * @method static void update(string $package, bool $dev = false) Updates a package dependency with an option for development.
+ * @method static void dumpAutoload(bool $optimize = false) Regenerates the Composer autoloader, with an option to optimize.
+ * @method static void runProcess(string|array $command) Executes a given Composer command using the process facade.
+ *
+ * @method static bool validateLicense(string $identifier) Validates if the provided license identifier is valid.
+ * @method static ?string getLicenseDefinition(string $identifier) Retrieves the detailed license definition from the SPDX source.
+ * @method static string requestLicenseDefinition(string $url) Makes an HTTP request to obtain the license definition from the given URL.
+ * @method static string getLicenseDefinitionFromHtml(string $html) Extracts the license definition text from retrieved HTML content.
+ */
 class Composer extends Facade
 {
     protected static function getFacadeAccessor(): string

--- a/app/Traits/Exceptions/LicenseDefinitionNotFound.php
+++ b/app/Traits/Exceptions/LicenseDefinitionNotFound.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Traits\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Throw when a license definition is not found for a given identifier.
+ */
+class LicenseDefinitionNotFound extends RuntimeException
+{
+    public function __construct(string $identifier)
+    {
+        parent::__construct("License definition for identifier {$identifier} not found.");
+    }
+}

--- a/app/Traits/WithLicense.php
+++ b/app/Traits/WithLicense.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Traits;
+
+use App\Traits\Exceptions\LicenseDefinitionNotFound;
+use Composer\Spdx\SpdxLicenses;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+trait WithLicense
+{
+    private SpdxLicenses $licenses;
+
+    private function getLicenses(): SpdxLicenses
+    {
+        if (empty($this->licenses)) {
+            $this->licenses = new SpdxLicenses();
+        }
+
+        return $this->licenses;
+    }
+
+    public function validateLicense(string $identifier): bool
+    {
+        return $this->getLicenses()->validate($identifier);
+    }
+
+    public function getLicenseDefinition(string $identifier): ?string
+    {
+        if (! $this->validateLicense($identifier)) {
+            return null;
+        }
+
+        $license = $this->getLicenses()->getLicenseByIdentifier($identifier);
+
+        try {
+            $definition = $this->requestLicenseDefinition($license[2]);
+        } catch (\Throwable) {
+            throw new LicenseDefinitionNotFound($identifier);
+        }
+
+        return $definition;
+    }
+
+    /**
+     * Requests the license definition from the given URL.
+     *
+     * @throws \Illuminate\Http\Client\RequestException in case the request fails.
+     * @throws \RuntimeException in case the license definition could not be found in the HTML.
+     */
+    private function requestLicenseDefinition(string $url): string
+    {
+        $html = Http::get($url)->throw()->body();
+
+        $definition = $this->getLicenseDefinitionFromHtml($html);
+
+        return $definition;
+    }
+
+    /**
+     * Extracts the license definition from the HTML.
+     *
+     * @throws RuntimeException in case the license definition could not be found in the HTML.
+     */
+    private function getLicenseDefinitionFromHtml(string $html): string
+    {
+        $dom = new \DOMDocument();
+        $dom->loadHTML($html);
+
+        $xpath = new \DOMXPath($dom);
+        $node = $xpath->query('//*[normalize-space(@class) = "license-text"]')->item(0);
+
+        if ($node === null) {
+            throw new \RuntimeException('No license definition found in the HTML');
+        }
+
+        return $node->nodeValue;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "php": "^8.3",
+        "composer/spdx-licenses": "^1.5",
         "laravel-zero/framework": "^11.36.1"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf522bef753b1a585d9eae5a4cba2992",
+    "content-hash": "cd3f61b94235ea5effc43a0159c42797",
     "packages": [
         {
             "name": "brick/math",
@@ -134,6 +134,86 @@
                 }
             ],
             "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "composer/spdx-licenses",
+            "version": "1.5.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/spdx-licenses.git",
+                "reference": "560bdcf8deb88ae5d611c80a2de8ea9d0358cc0a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/560bdcf8deb88ae5d611c80a2de8ea9d0358cc0a",
+                "reference": "560bdcf8deb88ae5d611c80a2de8ea9d0358cc0a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Spdx\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "SPDX licenses list and validation library.",
+            "keywords": [
+                "license",
+                "spdx",
+                "validator"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/spdx-licenses/issues",
+                "source": "https://github.com/composer/spdx-licenses/tree/1.5.8"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-11-20T07:44:33+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -9318,7 +9398,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2.0"
+        "php": "^8.3"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"


### PR DESCRIPTION
This **MR** includes the addition of a `trait` to use with the `Composer` class to validate license types and get the definition of a given license. The inclusion of this `trait` will help on future developments to include the definition (text) of a license valid for `Composer`